### PR TITLE
Relecture

### DIFF
--- a/vecteurs-indexation-et-assignation.Rmd
+++ b/vecteurs-indexation-et-assignation.Rmd
@@ -6,15 +6,15 @@ title: "Vecteurs, indexation et assignation"
 source("options_communes.R")
 ```
 
-Nous allons reprendre plusieurs éléments de base du langage **R** que nous avons déjà abordé mais de manière plus formelle. Une bonne compréhension des bases du langage, bien qu'un peu ardue de prime abord, permets de comprendre le sens des commandes que l'on utilise et de pleinement exploiter la puissance que **R** offre en matière de manipulation de données.
+Nous allons reprendre plusieurs éléments de base du langage **R** que nous avons déjà abordés mais de manière plus formelle. Une bonne compréhension des bases du langage, bien qu'un peu ardue de prime abord, permet de comprendre le sens des commandes qu'on utilise et de pleinement exploiter la puissance que **R** offre en matière de manipulation de données.
 
 Dans ce chapitre, nous reviendrons sur les vecteurs, tandis que les listes et les tableaux de données seront abordés dans un [chapitre dédié](listes-et-tableaux-de-donnes.html).
 
 ## Présentation des vecteurs
 
-Les <dfn data-index="vecteur">vecteurs</dfn> sont l'un des objets de bases de **R** et correspondent à une <q>liste de valeurs</q>. Leurs propriétés fondamentales sont :
+Les <dfn data-index="vecteur">vecteurs</dfn> sont l'un des objets de base de **R** et correspondent à une <q>liste de valeurs</q>. Leurs propriétés fondamentales sont :
 
-- les vecteurs sont unidimensionnels (i.e. c'est un objet à une seule dimension, à la différence d'une matrice par exemple) ;
+- les vecteurs sont unidimensionnels (i.e. ce sont des objets à une seule dimension, à la différence d'une matrice par exemple) ;
 - toutes les valeurs d'un vecteur sont d'un seul et même type ;
 - les vecteurs ont une longueur qui correspond au nombre de valeurs contenues dans le vecteur.
 
@@ -24,7 +24,7 @@ Dans **R**, il existe quatre types fondamentaux de vecteurs :
 
 - les <dfn data-index="nombre réel">nombres réels</dfn><dfn data-index="réel, nombre"></dfn> (c'est-à-dire les nombres décimaux que nous utilisons au quotidien), 
 - les <dfn data-index="nombre entier">nombres entiers</dfn><dfn data-index="entier, nombre"></dfn>, 
-- les <dfn data-index="chaîne de caractères">chaînes de caratères</dfn><dfn data-index="caractères, chaîne"></dfn> (qui correspondent à du <dfn>texte</dfn>) et 
+- les <dfn data-index="chaîne de caractères">chaînes de caractères</dfn><dfn data-index="caractères, chaîne"></dfn> (qui correspondent à du <dfn>texte</dfn>) et 
 - les <dfn data-index="valeur logique">valeurs logiques</dfn><dfn data-index="logique, valeur"></dfn> ou <dfn data-index="valeur booléenne">valeurs booléennes</dfn><dfn data-index="booléenne, valeur"></dfn>, à savoir <q>vrai</q> ou <q>faux</q>.
 
 Pour connaître la nature d'un objet, le plus simple est d'utiliser la fonction `class`{data-pkg="base"}. Par exemple :
@@ -41,13 +41,13 @@ Essayons avec un nombre entier :
 class(3)
 ```
 
-Sous **R**, lorsqu'on l'on tape un nombre sans autre précision, il est considéré par défaut comme un nombre réel. Pour indiquer spécifiquement que l'on veut un nombre entier, il faut rajouter le suffixe `L` :
+Sous **R**, lorsqu'on tape un nombre sans autre précision, il est considéré par défaut comme un nombre réel. Pour indiquer spécifiquement qu'on veut un nombre entier, il faut rajouter le suffixe `L` :
 
 ```{r}
 class(3L)
 ```
 
-Au quotidien, il arrive rarement d'avoir à utiliser ce suffixe, mais il est tonjour bon de le connaître au cas où vous le rencontriez dans des manuels ou des exemples de code.
+Au quotidien, il arrive rarement d'avoir à utiliser ce suffixe, mais il est toujours bon de le connaître au cas où vous le rencontriez dans des manuels ou des exemples de code.
 
 Pour saisir une chaîne de caractères, on aura recours aux doubles guillemets droits (`"`) :
 
@@ -55,7 +55,7 @@ Pour saisir une chaîne de caractères, on aura recours aux doubles guillemets d
 class("abc")
 ```
 
-Il est également possible d'utiliser des guillemets simples (`'`), dès lors que l'on utilise bien le même type de guillemets pour indiquer le début et la fin de la chaîne de caractères (par exemple `'abc'`).
+Il est également possible d'utiliser des guillemets simples (`'`), dès lors qu'on utilise bien le même type de guillemets pour indiquer le début et la fin de la chaîne de caractères (par exemple `'abc'`).
 
 Enfin, les valeurs logiques s'indiquent avec `TRUE` pour vrai et `FALSE` pour faux. Il est aussi possible d'utiliser les raccourcis `T` et `F`. Attention à bien utiliser les majuscules, **R** étant sensible à la casse.
 
@@ -100,7 +100,7 @@ urbain
 class(urbain)
 ```
 
-Nous l'avons vu, toutes les valeurs d'un vecteur doivent obligatoirement du même type. Dès lors, si l'on essaie de combiner des valeurs de différents types, **R** essaiera de les convertir au mieux. Par exemple :
+Nous l'avons vu, toutes les valeurs d'un vecteur doivent obligatoirement être du même type. Dès lors, si on essaie de combiner des valeurs de différents types, **R** essaiera de les convertir au mieux. Par exemple :
 
 ```{r}
 x <- c(2L, 3.14, "a")
@@ -112,7 +112,7 @@ Dans le cas présent, toutes les valeurs ont été converties en chaînes de car
 
 ### La fonction rep
 
-Dans certaines situations, on peut avoir besoin de créer un vecteur d'une certaine longeur mais dont toutes les valeurs sont identiques. Cela se réalise facilement avec `rep`{data-pkg="base"} à qui l'on indiquera la valeur à répéter puis le nombre de répétitions :
+Dans certaines situations, on peut avoir besoin de créer un vecteur d'une certaine longueur mais dont toutes les valeurs sont identiques. Cela se réalise facilement avec `rep`{data-pkg="base"} à qui on indiquera la valeur à répéter puis le nombre de répétitions :
 
 ```{r}
 rep(2, 10)
@@ -126,7 +126,7 @@ rep(c("a", "b"), 3)
 
 ### La fonction seq
 
-Dans d'autres situations, on peut avoir besoin de créer un vecteur contenant une suite de valeurs, ce qui se réalise aisément avec `seq`{data-pkg="base"} à qui l'on précisera les arguments `from` (point de départ), `to` (point d'arrivée) et `by` (pas). Quelques exemples valent mieux qu'un long discours :
+Dans d'autres situations, on peut avoir besoin de créer un vecteur contenant une suite de valeurs, ce qui se réalise aisément avec `seq`{data-pkg="base"} à qui on précisera les arguments `from` (point de départ), `to` (point d'arrivée) et `by` (pas). Quelques exemples valent mieux qu'un long discours :
 
 ```{r}
 seq(1, 10)
@@ -150,14 +150,14 @@ Nous verrons un peu plus loin que ce raccourci est fort pratique.
 
 ## Longueur d'un vecteur
 
-Un vecteur dispose donc d'une <dfn data-index="longueur, vecteur">longueur</dfn> qui correspond aux nombres de valeurs qui le compose. Elle s'obtient avec `length`{data-pkg="base"} :
+Un vecteur dispose donc d'une <dfn data-index="longueur, vecteur">longueur</dfn> qui correspond au nombre de valeurs qui le composent. Elle s'obtient avec `length`{data-pkg="base"} :
 
 ```{r}
 length(taille)
 length(c("a", "b"))
 ```
 
-Il est possible de faire un vecteur de longeur nulle avec `c()`. Bien évidemment sa longueur est zéro.
+Il est possible de faire un vecteur de longueur nulle avec `c()`. Bien évidemment sa longueur est zéro.
 
 ```{r}
 length(c())
@@ -203,7 +203,7 @@ length(min_maj)
 
 ## Valeurs manquantes
 
-Lorsque l'on travaille avec des données d'enquêtes, il est fréquent que certaines données soient manquantes, en raison d'un refus du participant de répondre à une question donnée ou d'un oubli ou d'un dystonctionnement du matériel de mesure, etc.
+Lorsqu'on travaille avec des données d'enquête, il est fréquent que certaines données soient manquantes, en raison d'un refus du participant de répondre à une question donnée ou d'un oubli ou d'un dysfonctionnement du matériel de mesure, etc.
 
 Une <dfn>valeur manquante</dfn><dfn data-index="manquante, valeur"></dfn> s'indique sous **R** avec `NA` (pour _not available_). Cette valeur peut s'appliquer à n'importe quel type de vecteur, qu'il soit numérique, textuel ou logique.
 
@@ -212,13 +212,13 @@ taille <- c(1.88, NA, 1.65, 1.92, 1.76, NA)
 sexe <- c("h", "f", NA, "h", NA, "f")
 ```
 
-Les valeurs manquantes sont prises en compte dans le calcul de la longeur du vecteur.
+Les valeurs manquantes sont prises en compte dans le calcul de la longueur du vecteur.
 
 ```{r}
 length(taille)
 ```
 
-Il ne faut pas confondre `NA`{data-pkg="base"} avec un autre objet que l'on rencontre sous **R** et appelé `NULL`{data-pkg="base"} qui représente l'<q>objet vide</q>. `NULL` ne contient absolument rien du tout. La différence se comprends mieux lorsque que l'on essaie de combiner ces objets :
+Il ne faut pas confondre `NA`{data-pkg="base"} avec un autre objet qu'on rencontre sous **R** qui s'appelle `NULL`{data-pkg="base"} et qui représente l'<q>objet vide</q>. `NULL` ne contient absolument rien. La différence se comprend mieux lorsqu'on essaie de combiner ces objets :
 
 ```{r}
 c(NULL, NULL, NULL)
@@ -238,7 +238,7 @@ Par contre, un vecteur composé de trois valeurs manquantes a une longueur de 3,
 ## Indexation par position
 
 
-L'<dfn>indexation</dfn> est l'une des fonctionnalités les plus puissantes mais aussi les plus difficiles à maîtriser de **R**. Il s'agit d'opérations permettant de sélectionner des sous-ensembles de valeurs en fonction de différents critères. Il existe trois types d'indexation : (i) l'indexation par position, (ii) l'indexation par nom et (iii) l'indexation par condition. Le principe est toujours le même : on indique entre crochets (`[]`) ce que l'on souhaite garder ou non. 
+L'<dfn>indexation</dfn> est l'une des fonctionnalités les plus puissantes mais aussi les plus difficiles à maîtriser de **R**. Il s'agit d'opérations permettant de sélectionner des sous-ensembles de valeurs en fonction de différents critères. Il existe trois types d'indexation : (i) l'indexation par position, (ii) l'indexation par nom et (iii) l'indexation par condition. Le principe est toujours le même : on indique entre crochets (`[]`) ce qu'on souhaite garder ou non. 
 
 Pour rappel, les crochets s'obtiennent sur un clavier français de type PC en appuyant sur la touche <kbd>Alt Gr</kbd> et la touche <kbd>(</kbd> ou <kbd>)</kbd>.
 
@@ -275,13 +275,13 @@ Il est tout à fait possible de sélectionner les valeurs dans le désordre :
 taille[c(5, 1, 4, 3)]
 ```
 
-Dans le cadre de l'indexation par position, il est également possible de spécifier des nombres négatifs. Auquel cas, cela signifiera <q>toutes les valeurs sauf celles-là</q>. Par exemple :
+Dans le cadre de l'indexation par position, il est également possible de spécifier des nombres négatifs, auquel cas cela signifiera <q>toutes les valeurs sauf celles-là</q>. Par exemple :
 
 ```{r}
 taille[c(-1, -5)]
 ```
 
-À noter, si l'on indique une position au-delà de la longueur du vecteur, **R** renverra `NA`. Par exemple :
+À noter, si on indique une position au-delà de la longueur du vecteur, **R** renverra `NA`. Par exemple :
 
 ```{r}
 taille[23:25]
@@ -289,19 +289,19 @@ taille[23:25]
 
 ## Des vecteurs nommés
 
-Les différentes valeurs d'un vecteur peuvent être nommés. Une première manière de nommer les éléments d'un vecteur est de le faire à sa création :
+Les différentes valeurs d'un vecteur peuvent être nommées. Une première manière de nommer les éléments d'un vecteur est de le faire à sa création :
 
 ```{r}
 sexe <- c(Michel = "h", Anne = "f", Dominique = NA, Jean = "h", Claude = NA, Marie = "f")
 ```
 
-Lorsque l'on affiche le vecteur, la présentation change quelque peu.
+Lorsqu'on affiche le vecteur, la présentation change quelque peu.
 
 ```{r}
 sexe
 ```
 
-La liste des noms s'obient avec `names`{data-pkg="base"}.
+La liste des noms s'obtient avec `names`{data-pkg="base"}.
 
 ```{r}
 names(sexe)
@@ -314,7 +314,7 @@ names(sexe) <- c("Michael", "Anna", "Dom", "John", "Alex", "Mary")
 sexe
 ```
 
-Pour supprimer tout les noms, il y a la fonction `unname`{data-pkg="base"} :
+Pour supprimer tous les noms, il y a la fonction `unname`{data-pkg="base"} :
 
 ```{r}
 anonyme <- unname(sexe)
@@ -341,7 +341,7 @@ sexe[names(sexe) != "Dom"]
 
 ## Indexation par condition
 
-L'<dfn>indexation par condition</dfn><dfn data-index="condition, indexation"></dfn> consiste à fournir un vecteur logique indiquant si chaque élément doit être inclu (si `TRUE`) ou exclu (si `FALSE`). Par exemple :
+L'<dfn>indexation par condition</dfn><dfn data-index="condition, indexation"></dfn> consiste à fournir un vecteur logique indiquant si chaque élément doit être inclus (si `TRUE`) ou exclu (si `FALSE`). Par exemple :
 
 ```{r}
 sexe
@@ -361,7 +361,7 @@ Le vecteur `urbain` est un vecteur logique. On peut directement l'utiliser pour 
 sexe[urbain]
 ```
 
-Supposons que l'on souhaite maintenant avoir la taille des individus pesant 80 kilogrammes ou plus. Nous pouvons effectuer une comparaison à l'aide des <dfn data-index="opérateur de comparaison">opérateurs de comparaison</dfn><dfn data-index="comparaison, opérateur"></dfn> suivants :
+Supposons qu'on souhaite maintenant avoir la taille des individus pesant 80 kilogrammes ou plus. Nous pouvons effectuer une comparaison à l'aide des <dfn data-index="opérateur de comparaison">opérateurs de comparaison</dfn><dfn data-index="comparaison, opérateur"></dfn> suivants :
 
 Opérateur de comparaison  | Signification
 :-----------|:-------------
@@ -378,7 +378,7 @@ Voyons tout de suite un exemple :
 poids >= 80
 ```
 
-Que s'est-il passé ? Nous avons fourni à **R** une condition et il nous a renvoyé un vecteur logique avec autant d'éléments qu'il y'a d'observations et dont la valeur est `TRUE` si la condition est remplie et `FALSE` dans les autres cas. Nous pouvons alors utiliser ce vecteur logique pour obtenir la taille des participants pesant 80 kilogrammes ou plus :
+Que s'est-il passé ? Nous avons fourni à **R** une condition et il nous a renvoyé un vecteur logique avec autant d'éléments qu'il y a d'observations et dont la valeur est `TRUE` si la condition est remplie et `FALSE` dans les autres cas. Nous pouvons alors utiliser ce vecteur logique pour obtenir la taille des participants pesant 80 kilogrammes ou plus :
 
 ```{r}
 taille[poids >= 80]
@@ -431,7 +431,7 @@ poids
 poids[taille > 1.8]
 ```
 
-Les éléments pour lesquels la taille n'est pas connue ont été transformés en `NA`, ce qui n'influera pas le calcul d'une moyenne. Par contre, lorsqu'on utilisera assignation et indexation ensemble, cela peut créer des problèmes. Il est donc préférable lorsque l'on a des valeurs manquantes de les exclure ainsi :
+Les éléments pour lesquels la taille n'est pas connue ont été transformés en `NA`, ce qui n'influera pas le calcul d'une moyenne. Par contre, lorsqu'on utilisera assignation et indexation ensemble, cela peut créer des problèmes. Il est donc préférable lorsqu'on a des valeurs manquantes de les exclure ainsi :
 
 ```{r}
 poids[taille > 1.8 & !is.na(taille)]
@@ -483,12 +483,12 @@ permettre de faire des recodages (que nous aborderons plus en détail dans un [c
 ## En résumé
 
 - Un vecteur est un objet unidimensionnel contenant une liste de valeurs qui sont toutes du même type (entières, numériques, textuelles ou logiques).
-- La fonction `class`{data-pkg="base"} permets de connaître le type de vecteur et la fonction `length`{data-pkg="base"} sa longueur, c'est-à-dire le nombre d'éléments du vecteur. 
+- La fonction `class`{data-pkg="base"} permet de connaître le type du vecteur et la fonction `length`{data-pkg="base"} sa longueur, c'est-à-dire son nombre d'éléments. 
 - La fonction `c`{data-pkg="base"} sert à créer et à combiner des vecteurs. 
 - Les valeurs manquantes sont représentées avec `NA`. 
-- Un vecteur peut être nommé, c'est-à-dire qu'un nom textuel a été associé à chaque élément. Cela peut se faire lors da sa création ou avec la fonction `names`{data-pkg="base"}. 
-- L'indexation consiste à extraire certains éléments d'un vecteur. Pour cela, on indique ce que l'on souhaite extraire entre crochets (`[]`) juste après le nom du vecteur. Le type d'indexation dépend du type d'information transmise. 
-- S'il s'agit de nombres entiers, c'est l'indexation par position : les nombres représent la position dans le vecteur des éléments que l'on souhaite extraire. Un nombre négatif s'interprète comme <q>tous les éléments sauf celui-là</q>. 
-- Si l'on indique des chaînes de caractères, c'est l'indexation par nom : on indique le nom des éléments que l'on souhaite extraire. Cette forme d'indexation ne fonctionne que si le vecteur est nommé. 
-- Si l'on transmets des valeurs logiques, le plus souvent sous la forme d'une condition, c'est l'indexation par condition : `TRUE` indique les éléments à extraire et `FALSE` les éléments à exclure. Il faut être vigilant aux valeurs manquantes (`NA`) dans ce cas précis. 
+- Un vecteur peut être nommé, c'est-à-dire qu'un nom textuel a été associé à chaque élément. Cela peut se faire lors de sa création ou avec la fonction `names`{data-pkg="base"}. 
+- L'indexation consiste à extraire certains éléments d'un vecteur. Pour cela, on indique ce qu'on souhaite extraire entre crochets (`[]`) juste après le nom du vecteur. Le type d'indexation dépend du type d'information transmise. 
+- S'il s'agit de nombres entiers, c'est l'indexation par position : les nombres représentent la position dans le vecteur des éléments qu'on souhaite extraire. Un nombre négatif s'interprète comme <q>tous les éléments sauf celui-là</q>. 
+- Si on indique des chaînes de caractères, c'est l'indexation par nom : on indique le nom des éléments qu'on souhaite extraire. Cette forme d'indexation ne fonctionne que si le vecteur est nommé. 
+- Si on transmet des valeurs logiques, le plus souvent sous la forme d'une condition, c'est l'indexation par condition : `TRUE` indique les éléments à extraire et `FALSE` les éléments à exclure. Il faut être vigilant aux valeurs manquantes (`NA`) dans ce cas précis. 
 - Enfin, il est possible de ne modifier que certains éléments d'un vecteur en ayant recours à la fois à l'indexation (`[]`) et à l'assignation (`<-`).


### PR DESCRIPTION
- Fautes de frappe
- J'ai aussi remplacé "que l'on", "parce que l'on", "si l'on" par "qu'on", "parce qu'on", "si on" pour homogénéiser et alléger.