### PR TITLE
Relecture

### DIFF
--- a/listes-et-tableaux-de-donnes.Rmd
+++ b/listes-et-tableaux-de-donnes.Rmd
@@ -12,24 +12,24 @@ Il est préférable d'avoir déjà lu le chapitre [Vecteurs, indexation et assig
 
 ## Listes
 
-Par nature, les vecteurs ne peuvent contenir que des valeurs de même type (numériques, textuels ou logique). Or, on peut avoir besoin de représenter des objets plus complexes composés d'éléments disparates. C'est ce que permettent les <dfn data-index="liste">listes</dfn>.
+Par nature, les vecteurs ne peuvent contenir que des valeurs de même type (numérique, textuel ou logique). Or, on peut avoir besoin de représenter des objets plus complexes composés d'éléments disparates. C'est ce que permettent les <dfn data-index="liste">listes</dfn>.
 
 ### Propriétés et création
 
-Une liste se créée tout simplement avec la fonction `list`{data-pkg="base"} :
+Une liste se crée tout simplement avec la fonction `list`{data-pkg="base"} :
 
 ```{r}
 l1 <- list(1:5, "abc")
 l1
 ```
 
-Une liste est un ensemble d'objets, quels qu'ils soient, chaque élément d'une liste pouvant avoir ses propres dimensions. Dans notre exemple précédent, nous avons créée une liste `l1` composée de deux élements : un vecteur d'entiers de longeur 5 et un vecteur textuel de longueur 1. La longueur d'une liste correspond aux nombres d'éléments qu'elle contient et s'obtient avec `length`{data-pkg="base"} :
+Une liste est un ensemble d'objets, quels qu'ils soient, chaque élément d'une liste pouvant avoir ses propres dimensions. Dans notre exemple précédent, nous avons créé une liste `l1` composée de deux éléments : un vecteur d'entiers de longueur 5 et un vecteur textuel de longueur 1. La longueur d'une liste correspond aux nombres d'éléments qu'elle contient et s'obtient avec `length`{data-pkg="base"} :
 
 ```{r}
 length(l1)
 ```
 
-Comme les vecteurs, une liste peut être nommées et les noms des éléments d'une liste accessibles avec `names`{data-pkg="base"} :
+Comme les vecteurs, une liste peut être nommée et les noms des éléments d'une liste sont accessibles avec `names`{data-pkg="base"} :
 
 ```{r}
 l2 <- list(minuscules = letters, majuscules = LETTERS, mois = month.name) 
@@ -38,7 +38,7 @@ length(l2)
 names(l2)
 ```
 
-Que se passe-t-il maintenant si l'on effectue la commande suivante ?
+Que se passe-t-il maintenant si on effectue la commande suivante ?
 
 ```{r}
 l <- list(l1, l2)
@@ -50,13 +50,13 @@ l <- list(l1, l2)
 length(l)
 ```
 
-Et bien non ! Elle est de longeur 2, car nous avons créé une liste composée de deux éléments qui sont eux-mêmes des listes. Cela est plus lisible si l'on fait appel à la fonction `str`{data-pkg="utils"} qui permet de visualiser la structure d'un objet.
+Eh bien non ! Elle est de longueur 2 car nous avons créé une liste composée de deux éléments qui sont eux-mêmes des listes. Cela est plus lisible si on fait appel à la fonction `str`{data-pkg="utils"} qui permet de visualiser la structure d'un objet.
 
 ```{r}
 str(l)
 ```
 
-Une liste peut contenir tout type d'objets, y compris d'autres listes. Pour combiner les éléments d'une liste, il faut utiliser la fonction `append`{data-pkg="base"} :
+Une liste peut contenir tous types d'objets, y compris d'autres listes. Pour combiner les éléments d'une liste, il faut utiliser la fonction `append`{data-pkg="base"} :
 
 ```{r}
 l <- append(l1, l2)
@@ -77,7 +77,7 @@ l[c("majuscules", "minuscules")]
 l[c(TRUE, TRUE, FALSE, FALSE, TRUE)]
 ```
 
-Même si l'on extrait un seul élément, l'extraction obtenue avec les crochets simples renvoie toujours une liste, ici composée d'un seul élément :
+Même si on extrait un seul élément, l'extraction obtenue avec les crochets simples renvoie toujours une liste, ici composée d'un seul élément :
 
 ```{r}
 str(l[1])
@@ -91,7 +91,7 @@ mean(l[1])
 
 Nous obtenons un message d'erreur. En effet, **R** ne sait pas calculer une moyenne à partir d'une liste. Ce qu'il lui faut, c'est un vecteur de valeurs numériques. Autrement dit, ce que nous cherchons à obtenir c'est le contenu même du premier élément de notre liste et non une liste à un seul élément.
 
-C'est ici que les doubles crochets (`[[]]`) vont rentrer en jeu. Pour ces derniers, nous pourrons utiliser l'indexation par position ou l'indexation par nom, mais pas l'indexation par condition. De plus, le critère que l'on indiquera doit indiquer *un et un seul* élément de notre liste. Au lieu de renvoyer une liste à un élément, les doubles crochets vont renvoyer l'élément désigné. Vite, un exemple :
+C'est ici que les doubles crochets (`[[]]`) vont rentrer en jeu. Pour ces derniers, nous pourrons utiliser l'indexation par position ou l'indexation par nom, mais pas l'indexation par condition. De plus, le critère qu'on indiquera doit indiquer *un et un seul* élément de notre liste. Au lieu de renvoyer une liste à un élément, les doubles crochets vont renvoyer l'élément désigné. Vite, un exemple :
 
 ```{r}
 str(l[1])
@@ -110,7 +110,7 @@ Nous pouvons aussi tester l'indexation par nom.
 l[["mois"]]
 ```
 
-Mais il faut avouer que cette écriture avec doubles crochets et guillemets est un peu lourde. Heureusement, un nouvel acteur entre en scène : le symbole dollar (`$`). C'est un raccourci des doubles crochets pour l'indexation par nom. Que l'on utilise ainsi :
+Mais il faut avouer que cette écriture avec doubles crochets et guillemets est un peu lourde. Heureusement, un nouvel acteur entre en scène : le symbole dollar (`$`). C'est un raccourci des doubles crochets pour l'indexation par nom qu'on utilise ainsi :
 
 ```{r}
 l$mois
@@ -139,13 +139,13 @@ Il y a un type d'objets que nous avons déjà abordé dans le chapitre [Premier 
 
 ### Propriétés et création
 
-Dans **R**, les tableaux de données sont tout simplement des listes avec quelques propriétés spéficiques :
+Dans **R**, les tableaux de données sont tout simplement des listes avec quelques propriétés spécifiques :
 
 - les tableaux de données ne peuvent contenir que des vecteurs ;
 - tous les vecteurs d'un tableau de données ont la même longueur ;
 - tous les éléments d'un tableau de données sont nommés et ont chacun un nom unique.
 
-Dès lors, un tableau de données correspond aux fichiers de données que l'on a l'habitude de manipuler dans d'autres logiciels de statistiques comme **SPSS** ou **Stata**. Les variables sont organisées en colonnes et les observations en lignes.
+Dès lors, un tableau de données correspond aux fichiers de données qu'on a l'habitude de manipuler dans d'autres logiciels de statistiques comme **SPSS** ou **Stata**. Les variables sont organisées en colonnes et les observations en lignes.
 
 On peut créer un tableau de données avec la fonction `data.frame`{data-pkg="base"} :
 
@@ -172,14 +172,14 @@ df
 str(df)
 ```
 
-Un tableau de données étant une liste, la fonction `length`{data-pkg="base"} renverra le nombre d'éléments de la liste, donc dans le cas présent le nombre de variables et `names`{data-pkg="base"} leurs noms :
+Un tableau de données étant une liste, la fonction `length`{data-pkg="base"} renverra le nombre d'éléments de la liste, donc dans le cas présent le nombre de variables, et `names`{data-pkg="base"} leurs noms :
 
 ```{r}
 length(df)
 names(df)
 ```
 
-Comme tous les éléments d'un tableau de données ont la même longeur, cet objet peut être vu comme bidimensionnel. Les fonctions `nrow`{data-pkg="base"}, `ncol`{data-pkg="base" data-rdoc="nrow"} et `dim`{data-pkg="base"} donnent respectivement le nombre de lignes, le nombre de colonnes et les dimensions de notre tableau.
+Comme tous les éléments d'un tableau de données ont la même longueur, cet objet peut être vu comme bidimensionnel. Les fonctions `nrow`{data-pkg="base"}, `ncol`{data-pkg="base" data-rdoc="nrow"} et `dim`{data-pkg="base"} donnent respectivement le nombre de lignes, le nombre de colonnes et les dimensions de notre tableau.
 
 ```{r}
 nrow(df)
@@ -222,14 +222,14 @@ df[3, "age"]
 df["Michael", 2]
 ```
 
-Il est également possible de ne préciser qu'un seul critère. Par exemple, si je souhaite les deux premières observations, ou les variables <var>sexe</var> et <var>blond</var> :
+Il est également possible de préciser un seul critère. Par exemple, si je souhaite les deux premières observations, ou les variables <var>sexe</var> et <var>blond</var> :
 
 ```{r}
 df[1:2,]
 df[,c("sexe", "blond")]
 ```
 
-Il a suffit de laisser un espace vide avant ou après la virgule. ATTENTION ! Il est cependant impératif de laisser la virgule pour indiquer à **R** que l'on souhaite effectuer une indexation à deux dimensions. Si l'on oublie la virgule, cela nous ramène au mode de fonctionnement des listes. Et le résultat n'est pas forcément le même :
+Il a suffi de laisser un espace vide avant ou après la virgule. ATTENTION ! Il est cependant impératif de laisser la virgule pour indiquer à **R** qu'on souhaite effectuer une indexation à deux dimensions. Si on oublie la virgule, cela nous ramène au mode de fonctionnement des listes. Et le résultat n'est pas forcément le même :
 
 ```{r}
 df[2, ]
@@ -247,12 +247,12 @@ str(df[2])
 str(df[[2]])
 ```
 
-`df[2, ]` signifie que l'on veut toutes les variables pour le second individu. Le résultat est un tableau de données à une ligne et trois colonnes. `df[2]` correspond au mode d'extraction des listes et renvoie donc une liste à un élément, en l'occurence un tableau de données à quatre observations et une variable. `df[[2]]` quant à lui renvoie le contenu de cette variable, soit un vecteur numérique de longeur quatre. Reste `df[, 2]` qui signifie renvoie toutes les observations pour la seconde colonne. Or l'<dfn>indexation bidimensionnelle</dfn> a un fonctionnement un peu particulier : par défaut cela renvoie un tableau de données mais s'il n'y a qu'une seule variable dans l'extraction, c'est un vecteur qui est renvoyé. Pour plus de détails, on pourra consulter l'entrée d'aide de `[.data.frame`{data-pkg="base" data-rdoc="Extract.data.frame"}.
+`df[2, ]` signifie qu'on veut toutes les variables pour le second individu. Le résultat est un tableau de données à une ligne et trois colonnes. `df[2]` correspond au mode d'extraction des listes et renvoie donc une liste à un élément, en l'occurrence un tableau de données à quatre observations et une variable. `df[[2]]` quant à lui renvoie le contenu de cette variable, soit un vecteur numérique de longueur quatre. Reste `df[, 2]` qui renvoie toutes les observations pour la seconde colonne. Or l'<dfn>indexation bidimensionnelle</dfn> a un fonctionnement un peu particulier : par défaut elle renvoie un tableau de données mais s'il y a une seule variable dans l'extraction, c'est un vecteur qui est renvoyé. Pour plus de détails, on pourra consulter l'entrée d'aide de `[.data.frame`{data-pkg="base" data-rdoc="Extract.data.frame"}.
 </div>
 
 ### Afficher les données
 
-Prenons un tableau de données un peu plus conséquent, en l'occurence un jeu de données disponible dans l'extension `questionr`{.pkg} et correspondant à un extrait de l'enquête *Histoire de vie* réalisée par l'INSEE en 2003.
+Prenons un tableau de données un peu plus conséquent, en l'occurrence un jeu de données disponible dans l'extension `questionr`{.pkg} et correspondant à un extrait de l'enquête *Histoire de vie* réalisée par l'INSEE en 2003.
 Il contient 2000 individus et 20 variables.
 
 ```{r}
@@ -261,7 +261,7 @@ data(hdv2003)
 d <- hdv2003
 ```
 
-Si l'on demande à afficher l'objet `d` dans la console (résultat non reproduit ici), **R** va afficher l'ensemble du contenu de `d` à l'écran ce qui, sur un tableau de cette taille, ne sera pas très lisible. Pour une exploration visuelle, le plus simple est souvent d'utiliser la <dfn>visionneuse</dfn> intégrée à **RStudio** et que l'on peut appeller avec la fonction `View`{data-pkg="utils"}.
+Si on demande d'afficher l'objet `d` dans la console (résultat non reproduit ici), **R** va afficher l'ensemble du contenu de `d` à l'écran ce qui, sur un tableau de cette taille, ne sera pas très lisible. Pour une exploration visuelle, le plus simple est souvent d'utiliser la <dfn>visionneuse</dfn> intégrée à **RStudio** et qu'on peut appeler avec la fonction `View`{data-pkg="utils"}.
 
 ```{r, eval=FALSE}
 View(d)
@@ -289,7 +289,7 @@ qui permet de lister les différentes variables d'un fichier de données :
 lookfor(d)
 ```
 
-Lorsque l'on a un gros tableau de données avec de nombreuses variables, il peut être difficile
+Lorsqu'on a un gros tableau de données avec de nombreuses variables, il peut être difficile
 de retrouver la ou les variables d'intérêt. Il est possible d'indiquer à `lookfor`{data-pkg="questionr"}
 un mot-clé pour limiter la recherche. Par exemple :
 
@@ -340,11 +340,11 @@ describe(d$sexe)
 **Les Listes**
 
 - Les listes sont des objets unidimensionnels pouvant contenir tout type d'objet, y compris d'autres listes.
-- Elles ont une longueur que l'obtient avec `length`{data-pkg="base"}.
-- On créé une liste avec `list`{data-pkg="base"} et on peut fusionner des listes avec `append`{data-pkg="base"}.
+- Elles ont une longueur qu'on obtient avec `length`{data-pkg="base"}.
+- On crée une liste avec `list`{data-pkg="base"} et on peut fusionner des listes avec `append`{data-pkg="base"}.
 - Tout comme les vecteurs, les listes peuvent être nommées et les noms des éléments s'obtiennent avec `names`{data-pkg="base"}.
 - Les crochets simples (`[]`) permettent de sélectionner les éléments d'une liste, en utilisant l'indexation par position, l'indexation par nom ou l'indexation par condition. Cela renvoie toujours une autre liste.
-- Les doubles crochets (`[[]]`) renvoient directement le contenu d'un élément de la liste que l'on aura sélectionné par position ou par nom.
+- Les doubles crochets (`[[]]`) renvoient directement le contenu d'un élément de la liste qu'on aura sélectionné par position ou par nom.
 - Le symbole `$` est un raccourci pour facilement sélectionner un élément par son nom, `liste$nom` étant équivalent à `liste[["nom"]]`.
 
 **Les Tableaux de données**
@@ -354,7 +354,7 @@ describe(d$sexe)
     ii. tous les vecteurs ont la même longueur ;
     iii. tous les vecteurs ont un nom et ce nom est unique.
 - On peut créer un tableau de données avec `data.frame`{data-pkg="base"}.
-- Les tableaux de données correspondent aux fichiers de données que l'on utilise usuellement dans d'autres logiciels de statistiques : les variables sont représentées en colonnes et les observations en lignes.
-- Ce sont des objets bidimensionnels : `ncol`{data-pkg="base" data-rdoc="nrow"} renvoit le nombre de colonnes et `nrow`{data-pkg="base"} le nombre de lignes.
+- Les tableaux de données correspondent aux fichiers de données qu'on utilise usuellement dans d'autres logiciels de statistiques : les variables sont représentées en colonnes et les observations en lignes.
+- Ce sont des objets bidimensionnels : `ncol`{data-pkg="base" data-rdoc="nrow"} renvoie le nombre de colonnes et `nrow`{data-pkg="base"} le nombre de lignes.
 - Les doubles crochets (`[[]]`) et le symbole dollar (`$`) fonctionnent comme pour les listes et permettent d'accéder aux variables.
 - Il est possible d'utiliser des coordonnées bidimensionnelles avec les crochets simples (`[]`) en indiquant un critère sur les lignes puis un critère sur les colonnes, séparés par une virgule (`,`).


### PR DESCRIPTION
- Fautes de frappe
- J'ai aussi remplacé "que l'on", "parce que l'on", "si l'on" par "qu'on", "parce qu'on", "si on" pour homogénéiser et alléger.