### PR TITLE
Edit link of ggplot2 extensions

### DIFF
--- a/etendre-ggplot2.Rmd
+++ b/etendre-ggplot2.Rmd
@@ -8,7 +8,7 @@ source("options_communes.R")
 
 De nombreuses extensions permettent d'étendre les possibilités graphiques de `ggplot2`{.pkg}. Certaines ont déjà été abordées dans les différents chapitres d'**analyse-R**. Le présent chapitre ne se veut pas exhaustif et ne présente qu'une sélection choisie d'extensions.
 
-Le site **ggplot2 extensions** (<http://www.ggplot2-exts.org/>) recense diverses extensions pour `ggplot2`{.pkg}.
+Le site **ggplot2 extensions** (<https://exts.ggplot2.tidyverse.org/gallery/>) recense diverses extensions pour `ggplot2`{.pkg}.
 
 Pour une présentation des fonctions de base et des concepts de `ggplot2`{.pkg}, on pourra se référer au [chapitre dédié](ggplot2.html) ainsi qu'au deux chapitres introductifs : [introduction à ggplot2](intro-ggplot2.html) et [graphiques bivariés avec ggplot2](graphiques-bivaries-ggplot2.html).
 


### PR DESCRIPTION
Old link redirects to a totally different kind of website.