### PR TITLE
Correction URLs vers "Introduction à R et au tidyverse"

### DIFF
--- a/manipuler-les-donnees-avec-dplyr.Rmd
+++ b/manipuler-les-donnees-avec-dplyr.Rmd
@@ -635,7 +635,7 @@ flights %>%
 
 ## Fonctions avancées
 
-On pourra consulter le chapitre [dplyr avancé](https://juba.github.io/tidyverse/17-dplyr-avance.html) de l'excellente *Introduction à R et au tidyverse* de Julien Barnier (<https://juba.github.io/tidyverse>).
+On pourra consulter le chapitre [dplyr avancé](https://juba.github.io/tidyverse/15-dplyr-avance.html) de l'excellente *Introduction à R et au tidyverse* de Julien Barnier (<https://juba.github.io/tidyverse>).
 
 Julien Barnier aborde notamment les fonctions `across`{data-pkg="dplyr"} pour appliquer une transformation à plusieurs colonnes, `rowwise`{data-pkg="dplyr"} et `c_across`{data-pkg="dplyr"} pour appliquer une transformation ligne à ligne, `rename_with`{data-pkg="dplyr"} pour renommer les colonnes à l'aide d'une fonction, ou encore la syntaxe abrégée permettant de définir des fonctions anonymes.
 

--- a/structures-conditionnelles.Rmd
+++ b/structures-conditionnelles.Rmd
@@ -254,4 +254,4 @@ beep("mario")
 
 ## Pour approfondir
 
-On pourra également consulter le chapitre [Boucles et exécution conditionnelle](https://juba.github.io/tidyverse/16-boucles-if.html) de l'excellente *Introduction à R et au tidyverse* de Julien Barnier (<https://juba.github.io/tidyverse>).
+On pourra également consulter le chapitre [Boucles et exécution conditionnelle](https://juba.github.io/tidyverse/17-if-boucles.html) de l'excellente *Introduction à R et au tidyverse* de Julien Barnier (<https://juba.github.io/tidyverse>).


### PR DESCRIPTION
Bonjour,

Je suis encore en train de travailler la partie "Aller plus loin" du doc "Introduction à R et au tidyverse", et suite à des retours j'ai déplacé un chapitre, ce qui a provoqué un changement de certaines URLs.

Je viens de voir que tu avais déjà mis des liens dans analyse-R, cette PR corrige les liens invalides.

Merci et désolé pour le désagrément !